### PR TITLE
chore: move create-cache imports to create cache cell

### DIFF
--- a/notebooks/06-deploy-with-momento-functions.ipynb
+++ b/notebooks/06-deploy-with-momento-functions.ipynb
@@ -42,18 +42,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "fad70990",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datetime import timedelta\n",
     "import base64\n",
     "import os\n",
     "from pathlib import Path\n",
     "from typing import Any, Mapping\n",
     "\n",
-    "from momento import CacheClient, Configurations, CredentialProvider\n",
+    "from momento import CredentialProvider\n",
     "import requests\n",
     "\n",
     "from momento_buffconf_workshop import ArticleContent"
@@ -69,13 +68,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "06fed22c",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Note that for the workshop you do not need to run this code.\n",
     "# A cache has already been created for you.\n",
+    "\n",
+    "# from datetime import timedelta\n",
+    "# from momento import CacheClient, Configurations\n",
     "\n",
     "# momento_client = CacheClient(\n",
     "#     Configurations.Laptop.v1(),\n",


### PR DESCRIPTION
In notebook 06 there is a workshop-specific flow (which uses the token
vending machine token) vs using a normal one. For the normal one we
can ensure the cache exists. For that code we need specific imports,
hence move those imports to that cell.
