### PR TITLE
chore: bump asset version in devcontainer env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
         "context": ".."
     },
 
-    "containerEnv": { "ASSET_VERSION": "20250725" },
+    "containerEnv": { "ASSET_VERSION": "20250728" },
     "onCreateCommand": "/bin/bash scripts/fetch-assets.sh",
 
     "hostRequirements": {"cpus": 4, "memory": "8gb"},


### PR DESCRIPTION
The latest version is 20250728. We bump to align with the available
release here.
