### PR TITLE
chore: explain embedding size from openai

### DIFF
--- a/notebooks/03-embed-content.ipynb
+++ b/notebooks/03-embed-content.ipynb
@@ -156,7 +156,7 @@
    "source": [
     "Since the embeddings API supports embedding batches of text at once, we can save on API calls by grouping the articles into batches. We'll use a batch size of 25 articles for this example.\n",
     "\n",
-    "TODO: explain the embeddings API converts text to vectors (as explained before), a point in high dimensional space. 1536-D to be exact. We won't explain how the embedding model does this in this talk."
+    "Recall: the embeddings API converts text to vectors, which are points in high dimensional space. The OpenAI embeddings have 1536 dimensions. Hence for each article, we get an array of 1536 floats."
    ]
   },
   {


### PR DESCRIPTION
Resolves TODO in embedding notebook: explains OpenAI text embedding
dimension size.
